### PR TITLE
Wait until the artifact is downloaded by SignPath (SIGN-6715)

### DIFF
--- a/actions/submit-signing-request/config.ts
+++ b/actions/submit-signing-request/config.ts
@@ -1,0 +1,5 @@
+export class Config {
+    MinDelayBetweenSigningRequestStatusChecksInSeconds = 10; // start from 10 sec
+    MaxDelayBetweenSigningRequestStatusChecksInSeconds = 60 * 20; // check at least every 30 minutes
+    CheckArtifactDownloadStatusIntervalInSeconds = 5;
+}

--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -37496,13 +37496,15 @@ class Task {
             this.configureAxios();
             try {
                 const signingRequestId = yield this.submitSigningRequest();
-                yield this.ensureSignPathDownloadedUnsignedArtifact(signingRequestId);
                 if (this.helperInputOutput.waitForCompletion) {
                     const signingRequest = yield this.ensureSigningRequestCompleted(signingRequestId);
                     this.helperInputOutput.setSignedArtifactDownloadUrl(signingRequest.signedArtifactLink);
                     if (this.helperInputOutput.outputArtifactDirectory) {
                         yield this.helperArtifactDownload.downloadSignedArtifact(signingRequest.signedArtifactLink);
                     }
+                }
+                else {
+                    yield this.ensureSignPathDownloadedUnsignedArtifact(signingRequestId);
                 }
             }
             catch (err) {

--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -37576,8 +37576,13 @@ class Task {
                 return signingRequestDto;
             }), this.helperInputOutput.waitForCompletionTimeoutInSeconds * 1000, this.config.CheckArtifactDownloadStatusIntervalInSeconds * 1000, this.config.CheckArtifactDownloadStatusIntervalInSeconds * 1000));
             if (!requestData.unsignedArtifactLink) {
-                const maxWaitingTime = moment.utc(this.helperInputOutput.waitForCompletionTimeoutInSeconds * 1000).format("hh:mm");
-                core.error(`We have exceeded the maximum waiting time, which is ${maxWaitingTime}, and the GitHub artifact is still not downloaded by SignPath`);
+                if (!requestData.isFinalStatus) {
+                    const maxWaitingTime = moment.utc(this.helperInputOutput.waitForCompletionTimeoutInSeconds * 1000).format("hh:mm");
+                    core.error(`We have exceeded the maximum waiting time, which is ${maxWaitingTime}, and the GitHub artifact is still not downloaded by SignPath`);
+                }
+                else {
+                    core.error(`The signing request is in its final state, but the GitHub artifact has not been downloaded by SignPath.`);
+                }
                 throw new Error(`The GitHub artifact is not downloaded by SignPath`);
             }
             else {

--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -87,6 +87,7 @@ class HelperArtifactDownload {
             });
             const targetDirectory = this.resolveOrCreateDirectory(this.helperInputOutput.outputArtifactDirectory);
             core.info(`The signed artifact is being downloaded from SignPath and will be saved to ${targetDirectory}`);
+            core.info(`Going to download signed artifact`);
             const rootTmpDir = process.env.RUNNER_TEMP;
             const tmpDir = fs.mkdtempSync(`${rootTmpDir}${path.sep}`);
             core.debug(`Created temp directory ${tmpDir}`);
@@ -37562,12 +37563,12 @@ class Task {
     // The token is valid only for the workflow's duration
     ensureSignPathDownloadedUnsignedArtifact(signingRequestId) {
         return __awaiter(this, void 0, void 0, function* () {
-            core.info(`Wait till SignPath downloads the unsigned artifact...`);
+            core.info(`Waiting until SignPath downloaded the unsigned artifact...`);
             const requestData = yield ((0, utils_1.executeWithRetries)(() => __awaiter(this, void 0, void 0, function* () {
                 const signingRequestDto = yield (this.getSigningRequest(signingRequestId)
                     .then(data => {
                     if (!data.unsignedArtifactLink && !data.isFinalStatus) {
-                        core.info(`The unsigned GitHub artifact is not yet downloaded by SignPath...`);
+                        core.info(`Checking the download status: not yet complete`);
                         throw new Error('Retry artifact download status check.');
                     }
                     return data;

--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -37777,7 +37777,7 @@ function executeWithRetries(promise, maxTotalWaitingTimeMs, minDelayMs, maxDelay
             else {
                 if (Date.now() - startTime > maxTotalWaitingTimeMs) {
                     const maxWaitingTime = moment.utc(Date.now() - startTime).format("hh:mm");
-                    throw new Error(result.retryReason || `The operation has timed out after ${maxWaitingTime}`);
+                    throw new Error(`The operation has timed out after ${maxWaitingTime}`);
                 }
                 core.info(`Next check in ${moment.duration(delayMs).humanize()}`);
                 yield new Promise(resolve => setTimeout(resolve, delayMs));

--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -37564,9 +37564,8 @@ class Task {
             const requestData = yield ((0, utils_1.executeWithRetries)(() => __awaiter(this, void 0, void 0, function* () {
                 const signingRequestDto = yield (this.getSigningRequest(signingRequestId)
                     .then(data => {
-                    console.log(`SignPath download status is ${data.unsignedArtifactLink ? 'completed' : 'not completed'}`);
                     if (!data.unsignedArtifactLink && !data.isFinalStatus) {
-                        core.info(`SignPath downloading the unsigned GitHub artifact...`);
+                        core.info(`The unsigned GitHub artifact is not yet downloaded by SignPath...`);
                         throw new Error('Retry artifact download status check.');
                     }
                     return data;

--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -37577,6 +37577,9 @@ class Task {
                 core.error(`We have exceeded the maximum waiting time, which is ${maxWaitingTime}, and the GitHub artifact is still not downloaded by SignPath`);
                 throw new Error(`The GitHub artifact is not downloaded by SignPath`);
             }
+            else {
+                core.info(`The unsigned GitHub artifact has been successfully downloaded by SignPath`);
+            }
             // else continue workflow execution
             // artifact already downloaded by SignPath
         });

--- a/actions/submit-signing-request/dtos/signing-request.ts
+++ b/actions/submit-signing-request/dtos/signing-request.ts
@@ -5,4 +5,5 @@ export interface SigningRequestDto
   signedArtifactLink: string;
   projectSlug: string;
   isFinalStatus: boolean;
+  unsignedArtifactLink: string;
 }

--- a/actions/submit-signing-request/helper-artifact-download.ts
+++ b/actions/submit-signing-request/helper-artifact-download.ts
@@ -28,6 +28,7 @@ export class HelperArtifactDownload {
 
         core.info(`The signed artifact is being downloaded from SignPath and will be saved to ${targetDirectory}`);
 
+        core.info(`Going to download signed artifact`);
         const rootTmpDir = process.env.RUNNER_TEMP;
         const tmpDir = fs.mkdtempSync(`${rootTmpDir}${path.sep}`);
         core.debug(`Created temp directory ${tmpDir}`);

--- a/actions/submit-signing-request/index.ts
+++ b/actions/submit-signing-request/index.ts
@@ -1,8 +1,10 @@
 import { Task } from "./task";
 import { HelperArtifactDownload } from "./helper-artifact-download";
 import { HelperInputOutput } from "./helper-input-output";
+import { Config } from "./config";
 
 const helperInputOutput = new HelperInputOutput();
 const helperArtifactDownload = new HelperArtifactDownload(helperInputOutput);
-const task = new Task(helperInputOutput, helperArtifactDownload);
+const config = new Config();
+const task = new Task(helperInputOutput, helperArtifactDownload, config);
 task.run();

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -119,13 +119,13 @@ export class Task {
     // ensure the workflow continues running until the download is complete.
     // The token is valid only for the workflow's duration
     private async ensureSignPathDownloadedUnsignedArtifact(signingRequestId: string): Promise<void> {
-        core.info(`Wait till SignPath downloads the unsigned artifact...`);
+        core.info(`Waiting until SignPath downloaded the unsigned artifact...`);
         const requestData = await (executeWithRetries<SigningRequestDto>(
             async () => {
                 const signingRequestDto = await (this.getSigningRequest(signingRequestId)
                     .then(data => {
                         if(!data.unsignedArtifactLink  && !data.isFinalStatus) {
-                            core.info(`The unsigned GitHub artifact is not yet downloaded by SignPath...`);
+                            core.info(`Checking the download status: not yet complete`);
                             throw new Error('Retry artifact download status check.');
                         }
                         return data;

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -137,8 +137,13 @@ export class Task {
             this.config.CheckArtifactDownloadStatusIntervalInSeconds * 1000));
 
         if (!requestData.unsignedArtifactLink) {
-            const maxWaitingTime = moment.utc(this.helperInputOutput.waitForCompletionTimeoutInSeconds * 1000).format("hh:mm");
-            core.error(`We have exceeded the maximum waiting time, which is ${maxWaitingTime}, and the GitHub artifact is still not downloaded by SignPath`);
+
+            if(!requestData.isFinalStatus) {
+                const maxWaitingTime = moment.utc(this.helperInputOutput.waitForCompletionTimeoutInSeconds * 1000).format("hh:mm");
+                core.error(`We have exceeded the maximum waiting time, which is ${maxWaitingTime}, and the GitHub artifact is still not downloaded by SignPath`);
+            } else {
+                core.error(`The signing request is in its final state, but the GitHub artifact has not been downloaded by SignPath.`);
+            }
             throw new Error(`The GitHub artifact is not downloaded by SignPath`);
         }
         else {

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -139,6 +139,9 @@ export class Task {
             core.error(`We have exceeded the maximum waiting time, which is ${maxWaitingTime}, and the GitHub artifact is still not downloaded by SignPath`);
             throw new Error(`The GitHub artifact is not downloaded by SignPath`);
         }
+        else {
+            core.info(`The unsigned GitHub artifact has been successfully downloaded by SignPath`);
+        }
         // else continue workflow execution
         // artifact already downloaded by SignPath
     }

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -35,7 +35,6 @@ export class Task {
 
         try {
             const signingRequestId = await this.submitSigningRequest();
-            await this.ensureSignPathDownloadedUnsignedArtifact(signingRequestId);
 
             if (this.helperInputOutput.waitForCompletion) {
                 const signingRequest = await this.ensureSigningRequestCompleted(signingRequestId);
@@ -44,6 +43,9 @@ export class Task {
                 if(this.helperInputOutput.outputArtifactDirectory) {
                     await this.helperArtifactDownload.downloadSignedArtifact(signingRequest.signedArtifactLink);
                 }
+            }
+            else {
+                await this.ensureSignPathDownloadedUnsignedArtifact(signingRequestId);
             }
         }
         catch (err) {

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -122,9 +122,8 @@ export class Task {
             async () => {
                 const signingRequestDto = await (this.getSigningRequest(signingRequestId)
                     .then(data => {
-                        console.log(`SignPath download status is ${data.unsignedArtifactLink ? 'completed' : 'not completed'}`);
                         if(!data.unsignedArtifactLink  && !data.isFinalStatus) {
-                            core.info(`SignPath downloading the unsigned GitHub artifact...`);
+                            core.info(`The unsigned GitHub artifact is not yet downloaded by SignPath...`);
                             throw new Error('Retry artifact download status check.');
                         }
                         return data;

--- a/actions/submit-signing-request/tests/utils.test.ts
+++ b/actions/submit-signing-request/tests/utils.test.ts
@@ -7,10 +7,10 @@ it('test execute with retries, eventually successful', async () => {
         counter++;
 
         if (counter < 3) {
-            throw new Error('error');
+            return { retry: true, result: null };
         }
 
-        return 'success';
+        return { retry: false, result: 'success' };
     };
 
     const result = await executeWithRetries(promise, 100, 1, 3);
@@ -21,7 +21,7 @@ it('test execute with retries, eventually successful', async () => {
 /// the test checks that error will be thrown if the promise always fails
 it('test execute with retries - error', async () => {
     const promise = async () => {
-        throw new Error('error');
+        return { retry: true, result: null };
     };
 
     try {
@@ -29,6 +29,6 @@ it('test execute with retries - error', async () => {
         assert.fail('error should be thrown');
     }
     catch (err: any) {
-        expect(err.message).to.eq('error');
+        expect(err.message).contains('timed');
     }
 });

--- a/actions/submit-signing-request/utils.ts
+++ b/actions/submit-signing-request/utils.ts
@@ -11,7 +11,6 @@ import { AxiosError, AxiosResponse } from 'axios';
 
 export interface ExecuteWithRetriesResult<RES> {
     retry: boolean;
-    retryReason?: string;
     result?: RES;
 }
 
@@ -30,7 +29,7 @@ export async function executeWithRetries<RES>(
         else {
             if (Date.now() - startTime > maxTotalWaitingTimeMs) {
                 const maxWaitingTime = moment.utc(Date.now() - startTime).format("hh:mm");
-                throw new Error(result.retryReason || `The operation has timed out after ${maxWaitingTime}`);
+                throw new Error(`The operation has timed out after ${maxWaitingTime}`);
             }
             core.info(`Next check in ${moment.duration(delayMs).humanize()}`);
             await new Promise(resolve => setTimeout(resolve, delayMs));

--- a/actions/submit-signing-request/utils.ts
+++ b/actions/submit-signing-request/utils.ts
@@ -9,27 +9,35 @@ import { AxiosError, AxiosResponse } from 'axios';
 /// 3. stop when maxTotalWaitingTimeMs is reached
 /// 4. if maxDelayMs is reached, use it for all subsequent calls
 
+export interface ExecuteWithRetriesResult<RES> {
+    retry: boolean;
+    retryReason?: string;
+    result?: RES;
+}
+
 export async function executeWithRetries<RES>(
-    promise: () => Promise<RES>,
+    promise: () => Promise<ExecuteWithRetriesResult<RES>>,
     maxTotalWaitingTimeMs: number, minDelayMs: number, maxDelayMs: number): Promise<RES> {
     const startTime = Date.now();
     let delayMs = minDelayMs;
-    let result: RES;
+    let result: ExecuteWithRetriesResult<RES>;
     while (true) {
-        try {
-            result = await promise();
+        result = await promise();
+
+        if(result.retry === false) {
             break;
         }
-        catch (err) {
+        else {
             if (Date.now() - startTime > maxTotalWaitingTimeMs) {
-                throw err;
+                const maxWaitingTime = moment.utc(Date.now() - startTime).format("hh:mm");
+                throw new Error(result.retryReason || `The operation has timed out after ${maxWaitingTime}`);
             }
             core.info(`Next check in ${moment.duration(delayMs).humanize()}`);
             await new Promise(resolve => setTimeout(resolve, delayMs));
             delayMs = Math.min(delayMs * 2, maxDelayMs);
         }
     }
-    return result;
+    return result.result!;
 }
 
 export function getInputNumber(name: string, options?: core.InputOptions): number {


### PR DESCRIPTION
Added a waiting loop for the 'fire and forget' mode to wait until the artifact is downloaded by SignPath, and only then proceed. 