### PR TITLE
SIGN-6769 - use gha base url specified in the app settings

### DIFF
--- a/actions/submit-signing-request/dist/index.js
+++ b/actions/submit-signing-request/dist/index.js
@@ -37651,7 +37651,6 @@ class Task {
         return {
             apiToken: this.helperInputOutput.signPathApiToken,
             artifactName: this.helperInputOutput.githubArtifactName,
-            gitHubApiUrl: process.env.GITHUB_API_URL,
             gitHubWorkflowRunId: process.env.GITHUB_RUN_ID,
             gitHubRepository: process.env.GITHUB_REPOSITORY,
             gitHubToken: this.helperInputOutput.gitHubToken,

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -249,7 +249,6 @@ export class Task {
         return {
             apiToken: this.helperInputOutput.signPathApiToken,
             artifactName: this.helperInputOutput.githubArtifactName,
-            gitHubApiUrl: process.env.GITHUB_API_URL,
             gitHubWorkflowRunId: process.env.GITHUB_RUN_ID,
             gitHubRepository: process.env.GITHUB_REPOSITORY,
             gitHubToken: this.helperInputOutput.gitHubToken,


### PR DESCRIPTION
In order to prevent attackers from providing us with a fake Github API URL,
we will use one from the configuration instead of the one provided by the GHA custom action