### PR TITLE
SIGN-6981 - added gitHubWorkflowRunAttempt to the signing request pay…

### DIFF
--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -301,6 +301,7 @@ export class Task {
             signPathApiToken: this.helperInputOutput.signPathApiToken,
             artifactName: this.helperInputOutput.githubArtifactName,
             gitHubWorkflowRunId: process.env.GITHUB_RUN_ID,
+            gitHubWorkflowRunAttempt: process.env.GITHUB_RUN_ATTEMPT,
             gitHubRepository: process.env.GITHUB_REPOSITORY,
             gitHubRepositoryOwner: process.env.GITHUB_REPOSITORY_OWNER,
             gitHubToken: this.helperInputOutput.gitHubToken,

--- a/actions/submit-signing-request/tests/task.test.ts
+++ b/actions/submit-signing-request/tests/task.test.ts
@@ -171,7 +171,13 @@ it('test that the connectors url has api version', async () => {
         })), true);
 });
 
-it('test if input variables are passed through', async () => {
+it('test if input and env variables are passed through', async () => {
+
+    process.env.GITHUB_RUN_ID = '123';
+    process.env.GITHUB_RUN_ATTEMPT = '999';
+    process.env.GITHUB_REPOSITORY = 'test/test';
+    process.env.GITHUB_REPOSITORY_OWNER = 'owner';
+
     await task.run();
     assert.equal(axiosPostStub.calledWith(
         sinon.match.any,
@@ -183,7 +189,12 @@ it('test if input variables are passed through', async () => {
                 && value.signPathSigningPolicySlug === testSigningPolicySlug
                 && value.gitHubToken === testGitHubToken
                 && value.gitHubExtendedVerificationToken === testGitHubExtendedVerificationToken
-                && value.signPathArtifactConfigurationSlug === testArtifactConfigurationSlug;
+                && value.signPathArtifactConfigurationSlug === testArtifactConfigurationSlug
+
+                && value.gitHubWorkflowRunId === process.env.GITHUB_RUN_ID
+                && value.gitHubWorkflowRunAttempt === process.env.GITHUB_RUN_ATTEMPT
+                && value.gitHubRepository === process.env.GITHUB_REPOSITORY
+                && value.gitHubRepositoryOwner === process.env.GITHUB_REPOSITORY_OWNER;
         })), true);
 });
 

--- a/actions/submit-signing-request/version.ts
+++ b/actions/submit-signing-request/version.ts
@@ -1,2 +1,2 @@
-const taskVersion = '0.3';
+const taskVersion = '0.4';
 export { taskVersion };


### PR DESCRIPTION
I added gitHubWorkflowRunAttempt to the signing request payload. The GitHub Actions (GHA) connector will then pass it along to SignPath as part of the create signing request call.