### PR TITLE
SIGN-7199 - removed extended verification token. Updated version to 1.1

### DIFF
--- a/actions/submit-signing-request/action.yml
+++ b/actions/submit-signing-request/action.yml
@@ -31,9 +31,6 @@ inputs:
     description: 'GitHub access token used to read job details and download the artifact. Defaults to the [`secrets.GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).'
     default: ${{ github.token }}
     required: false
-  github-extended-verification-token:
-    description: 'Preview only: Contact SignPath support for details.'
-    required: false
   parameters:
     description: 'Multiline-string of values that map to user-defined parameters in the Artifact Configuration. Use one line per parameter with the format <name>: "<value>" where <value> needs to be a valid JSON string.'
     required: false

--- a/actions/submit-signing-request/helper-input-output.ts
+++ b/actions/submit-signing-request/helper-input-output.ts
@@ -35,10 +35,6 @@ export class HelperInputOutput {
         return core.getInput('github-token', { required: true });
     }
 
-    get gitHubExtendedVerificationToken(): string {
-        return core.getInput('github-extended-verification-token', { required: false });
-    }
-
     get parameters(): {name:string, value: string}[] {
         const value = core.getInput('parameters', { required: false });
         return parseUserDefinedParameters(value);

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -304,7 +304,6 @@ export class Task {
             gitHubRepository: process.env.GITHUB_REPOSITORY,
             gitHubRepositoryOwner: process.env.GITHUB_REPOSITORY_OWNER,
             gitHubToken: this.helperInputOutput.gitHubToken,
-            gitHubExtendedVerificationToken: this.helperInputOutput.gitHubExtendedVerificationToken,
             signPathOrganizationId: this.helperInputOutput.organizationId,
             signPathProjectSlug: this.helperInputOutput.projectSlug,
             signPathSigningPolicySlug: this.helperInputOutput.signingPolicySlug,

--- a/actions/submit-signing-request/tests/task.test.ts
+++ b/actions/submit-signing-request/tests/task.test.ts
@@ -23,7 +23,6 @@ const testOrganizationId = 'TEST_ORGANIZATION_ID';
 const testProjectSlug = 'TEST_PROJECT_SLUG';
 const testSigningPolicySlug = 'TEST_POLICY_SLUG';
 const testGitHubToken = 'TEST_GITHUB_TOKEN';
-const testGitHubExtendedVerificationToken = 'TEST_GITHUB_EXTENDED_VERIFICATION_TOKEN';
 
 const defaultTestInputMap = {
     'wait-for-completion': 'true',
@@ -34,7 +33,6 @@ const defaultTestInputMap = {
     'api-token': testSignPathApiToken,
     'github-artifact-id': testGitHubArtifactId,
     'github-token': testGitHubToken,
-    'github-extended-verification-token': testGitHubExtendedVerificationToken,
     'organization-id': testOrganizationId,
     'project-slug': testProjectSlug,
     'signing-policy-slug': testSigningPolicySlug,
@@ -183,7 +181,6 @@ it('test if input variables are passed through', async () => {
                 && value.signPathProjectSlug === testProjectSlug
                 && value.signPathSigningPolicySlug === testSigningPolicySlug
                 && value.gitHubToken === testGitHubToken
-                && value.gitHubExtendedVerificationToken === testGitHubExtendedVerificationToken
                 && value.signPathArtifactConfigurationSlug === testArtifactConfigurationSlug
                 && value.parameters.length === 1
                 && value.parameters[0].name === 'param1'

--- a/actions/submit-signing-request/version.ts
+++ b/actions/submit-signing-request/version.ts
@@ -1,2 +1,2 @@
-const taskVersion = '0.5';
+const taskVersion = '1.1';
 export { taskVersion };


### PR DESCRIPTION
We use an application token for all cases where elevated permissions are required, so we no longer need an extended verification token. 