### PR TITLE
SIGN-7471 - connector logs support

### DIFF
--- a/actions/submit-signing-request/dtos/submit-signing-request-result.ts
+++ b/actions/submit-signing-request/dtos/submit-signing-request-result.ts
@@ -3,6 +3,7 @@ export interface SubmitSigningRequestResult {
     validationResult: ValidationResult;
     signingRequestUrl: string;
     error: string;
+    logs: LogEntry[];
 }
 
 export interface ValidationResult {
@@ -13,3 +14,13 @@ export interface ValidationError {
     error: string;
     howToFix: string;
 }
+
+export interface LogEntry {
+    message: string;
+    level: string;
+}
+
+export const LogLevelDebug = "Debug";
+export const LogLevelInformation = "Information";
+export const LogLevelWarning = "Warning";
+export const LogLevelError = "Error";

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -306,7 +306,6 @@ export class Task {
                         core.debug(log.message);
                         break;
                     case LogLevelInformation:
-                        console.log('asdasdasdasdasd');
                         core.info(log.message);
                         break;
                     case LogLevelWarning:

--- a/actions/submit-signing-request/task.ts
+++ b/actions/submit-signing-request/task.ts
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 import * as moment from 'moment';
 import url from 'url';
 
-import { SubmitSigningRequestResult, ValidationResult } from './dtos/submit-signing-request-result';
+import { LogEntry, LogLevelDebug, LogLevelError, LogLevelInformation, LogLevelWarning, SubmitSigningRequestResult, ValidationResult } from './dtos/submit-signing-request-result';
 import { buildSignPathAuthorizationHeader, executeWithRetries, httpErrorResponseToText } from './utils';
 import { SignPathUrlBuilder } from './signpath-url-builder';
 import { SigningRequestDto } from './dtos/signing-request';
@@ -88,6 +88,7 @@ export class Task {
 
         this.checkResponseStructure(response);
         this.checkCiSystemValidationResult(response.validationResult);
+        this.redirectConnectorLogsToActionLogs(response.logs);
 
         const signingRequestUrlObj  = url.parse(response.signingRequestUrl);
         this.urlBuilder.signPathBaseUrl = signingRequestUrlObj.protocol + '//' + signingRequestUrlObj.host;
@@ -292,7 +293,33 @@ export class Task {
 
             // if neither validationResult nor signingRequestId are present,
             // then the response might be not from the connector
+            core.error(`Unexpected response from the SignPath connector: ${JSON.stringify(response)}`);
             throw new Error(`SignPath signing request was not created. Please make sure that connector-url is pointing to the SignPath GitHub Actions connector endpoint.`);
+        }
+    }
+
+    private redirectConnectorLogsToActionLogs(logs: LogEntry[]): void {
+        if (logs && logs.length > 0) {
+            logs.forEach(log => {
+                switch (log.level) {
+                    case LogLevelDebug:
+                        core.debug(log.message);
+                        break;
+                    case LogLevelInformation:
+                        console.log('asdasdasdasdasd');
+                        core.info(log.message);
+                        break;
+                    case LogLevelWarning:
+                        core.warning(log.message);
+                        break;
+                    case LogLevelError:
+                        core.error(log.message);
+                        break;
+                    default:
+                        core.info(log.message);
+                        break;
+                }
+            });
         }
     }
 

--- a/actions/submit-signing-request/tests/task.test.ts
+++ b/actions/submit-signing-request/tests/task.test.ts
@@ -24,6 +24,7 @@ const testOrganizationId = 'TEST_ORGANIZATION_ID';
 const testProjectSlug = 'TEST_PROJECT_SLUG';
 const testSigningPolicySlug = 'TEST_POLICY_SLUG';
 const testGitHubToken = 'TEST_GITHUB_TOKEN';
+const testConnectorLogMessage = 'TEST_CONNECTOR_LOG_MESSAGE';
 
 const defaultTestInputMap = {
     'wait-for-completion': 'true',
@@ -61,7 +62,7 @@ beforeEach(() => {
         status: 'Completed',
         unsignedArtifactLink: testUnsignedArtifactLink,
         signedArtifactLink: testSignedArtifactLink,
-        logs: [ { message: 'TEST_MESSAGE', level: 'Information' } ]
+        logs: [ { message: testConnectorLogMessage, level: 'Information' } ]
     };
 
     const getSigningRequestResponse = submitSigningRequestResponse;
@@ -145,7 +146,7 @@ it('test that the signing request was not submitted due to validation errors', a
             return value.includes('TEST_ERROR');
         }));
     // check that howToFix message was logged
-    const infoLogStub = sandbox.stub(core, 'info')
+    const coreInfoStub = sandbox.stub(core, 'info')
         .withArgs(sinon.match((value:any) => {
             return value.includes('TEST_FIX');
         }));
@@ -153,7 +154,7 @@ it('test that the signing request was not submitted due to validation errors', a
     await task.run();
     assert.equal(setFailedStub.calledOnce, true);
     assert.equal(errorLogStub.called, true);
-    assert.equal(infoLogStub.called, true);
+    assert.equal(coreInfoStub.called, true);
 });
 
 it('test that the output variables are set correctly', async () => {
@@ -162,6 +163,15 @@ it('test that the output variables are set correctly', async () => {
     assert.equal(setOutputStub.calledWith('signing-request-web-url', testSigningRequestUrl), true);
     assert.equal(setOutputStub.calledWith('signpath-api-url', testSignPathUrl + '/API'), true);
     assert.equal(setOutputStub.calledWith('signed-artifact-download-url', testSignedArtifactLink), true);
+});
+
+it('connector logs logged to the build log', async () => {
+    const coreInfoStub = sandbox.stub(core, 'info')
+        .withArgs(sinon.match((value:any) => {
+            return value.includes(testConnectorLogMessage);
+        }));
+    await task.run();
+    assert.equal(coreInfoStub.called, true);
 });
 
 it('test that the connectors url has api version', async () => {

--- a/actions/submit-signing-request/tests/task.test.ts
+++ b/actions/submit-signing-request/tests/task.test.ts
@@ -9,6 +9,7 @@ import { HelperInputOutput } from '../helper-input-output';
 import { HelperArtifactDownload } from '../helper-artifact-download';
 import axiosRetry from 'axios-retry';
 import { Config } from '../config';
+import { log } from 'console';
 
 const testSignPathApiToken = 'TEST_TOKEN';
 const testSigningRequestId = 'TEST_ID';
@@ -59,7 +60,8 @@ beforeEach(() => {
         isFinalStatus: true,
         status: 'Completed',
         unsignedArtifactLink: testUnsignedArtifactLink,
-        signedArtifactLink: testSignedArtifactLink
+        signedArtifactLink: testSignedArtifactLink,
+        logs: [ { message: 'TEST_MESSAGE', level: 'Information' } ]
     };
 
     const getSigningRequestResponse = submitSigningRequestResponse;


### PR DESCRIPTION
- Added support for connector-side logs.
- Log server response to the build log if we cannot deserialize it 